### PR TITLE
Add simple CLI allowance management app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+allowance_data.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # my-codex-test
+
+This repository includes a simple command-line allowance management app written in Python.
+
+## Usage
+
+```bash
+python allowance_app.py
+```
+Follow the prompts to add allowance, record spending, set a savings goal, and view your balance.

--- a/allowance_app.py
+++ b/allowance_app.py
@@ -1,0 +1,73 @@
+import json
+import os
+
+DATA_FILE = 'allowance_data.json'
+
+class AllowanceApp:
+    def __init__(self):
+        self.balance = 0
+        self.goal = None
+        self.load()
+
+    def load(self):
+        if os.path.exists(DATA_FILE):
+            with open(DATA_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                self.balance = data.get('balance', 0)
+                self.goal = data.get('goal')
+
+    def save(self):
+        with open(DATA_FILE, 'w', encoding='utf-8') as f:
+            json.dump({'balance': self.balance, 'goal': self.goal}, f)
+
+    def add(self, amount):
+        self.balance += amount
+        self.save()
+        print(f'{amount}円を追加しました。現在の残高: {self.balance}円')
+
+    def spend(self, amount):
+        if amount > self.balance:
+            print('残高が足りません。')
+            return
+        self.balance -= amount
+        self.save()
+        print(f'{amount}円を使いました。現在の残高: {self.balance}円')
+
+    def show(self):
+        print(f'現在の残高: {self.balance}円')
+        if self.goal is not None:
+            print(f'目標金額: {self.goal}円')
+            if self.balance >= self.goal:
+                print('おめでとう! 目標を達成しました!')
+            else:
+                print(f'目標まであと {self.goal - self.balance}円')
+
+    def set_goal(self, amount):
+        self.goal = amount
+        self.save()
+        print(f'目標金額を{self.goal}円に設定しました。')
+
+    def run(self):
+        print('--- お小遣い管理アプリ ---')
+        while True:
+            cmd = input('add(追加)/spend(使う)/show(確認)/goal(目標設定)/exit: ').strip().lower()
+            if cmd == 'add':
+                amount = int(input('追加する金額: '))
+                self.add(amount)
+            elif cmd == 'spend':
+                amount = int(input('使った金額: '))
+                self.spend(amount)
+            elif cmd == 'show':
+                self.show()
+            elif cmd == 'goal':
+                amount = int(input('目標金額: '))
+                self.set_goal(amount)
+            elif cmd == 'exit':
+                print('終了します。')
+                break
+            else:
+                print('不明なコマンドです。')
+
+if __name__ == '__main__':
+    app = AllowanceApp()
+    app.run()


### PR DESCRIPTION
## Summary
- implement a Python command-line allowance manager that tracks balance, spending, and savings goals
- document usage in README
- ignore generated data file in .gitignore

## Testing
- `python allowance_app.py <<'EOF'
show
add
500
show
spend
200
show
goal
1000
show
add
800
show
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68b6ed0a8d7c8328acd60dd25a33350a